### PR TITLE
feat: add `wrapperStyle` prop to `AnimatedGlow`

### DIFF
--- a/src/AnimatedGlow.tsx
+++ b/src/AnimatedGlow.tsx
@@ -39,6 +39,7 @@ const AnimatedGlow: FC<AnimatedGlowProps> = (props) => {
         style, 
         isVisible = true, 
         activeState: activeStateProp,
+        wrapperStyle: wrapperStyleProp,
         ...overrideProps 
     } = props;
     
@@ -94,13 +95,16 @@ const AnimatedGlow: FC<AnimatedGlowProps> = (props) => {
     const hasGlowLayers = (targetConfig.glowLayers?.length ?? 0) > 0;
     const useSkiaRenderer = useMemo(() => hasGlowLayers || hasAnimatedBorder, [hasGlowLayers, hasAnimatedBorder]);
 
-    const wrapperStyle = useMemo<StyleProp<ViewStyle>>(() => ({
-        backgroundColor: useSkiaRenderer ? 'transparent' : backgroundColor,
-        borderWidth: useSkiaRenderer ? 0 : outlineWidth,
-        borderColor: useSkiaRenderer ? 'transparent' : (Array.isArray(borderColor) ? borderColor[0] : borderColor),
-        borderRadius: cornerRadius,
-        overflow: 'hidden',
-    }), [useSkiaRenderer, outlineWidth, borderColor, cornerRadius, backgroundColor]);
+    const wrapperStyle = useMemo<StyleProp<ViewStyle>>(() => [
+        {
+            backgroundColor: useSkiaRenderer ? 'transparent' : backgroundColor,
+            borderWidth: useSkiaRenderer ? 0 : outlineWidth,
+            borderColor: useSkiaRenderer ? 'transparent' : (Array.isArray(borderColor) ? borderColor[0] : borderColor),
+            borderRadius: cornerRadius,
+            overflow: 'hidden',
+        },
+        wrapperStyleProp,
+    ], [useSkiaRenderer, outlineWidth, borderColor, cornerRadius, backgroundColor, wrapperStyleProp]);
     
     const shouldRenderSkia = useSkiaRenderer && hasLaidOut && isVisible;
 

--- a/src/animated-glow/types.ts
+++ b/src/animated-glow/types.ts
@@ -54,6 +54,7 @@ export interface AnimatedGlowProps extends Partial<GlowConfig> {
   style?: StyleProp<ViewStyle>;
   isVisible?: boolean;
   activeState?: GlowEvent;
+  wrapperStyle?: StyleProp<ViewStyle>;
 }
 
 export type Layout = { width: number; height: number };


### PR DESCRIPTION
I ran into a scenario where I needed to add some styling to the `View` component that the child of `AnimatedGlow` is wrapped with (I needed to add `flex: 1` to the wrapper). I did a patch but I think this would be a useful prop for other folks as well.